### PR TITLE
Update to 2024.1 dependencies

### DIFF
--- a/src/Seq.App.Replication/Seq.App.Replication.csproj
+++ b/src/Seq.App.Replication/Seq.App.Replication.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <Description>A simple event forwarder for Seq. Requires Seq 2023.4+.</Description>
+    <Description>A simple event forwarder for Seq. Requires Seq 2024.1+.</Description>
     <Authors>Datalust and Contributors</Authors>
     <PackageTags>seq-app</PackageTags>
     <PackageIcon>seq-app-replication.png</PackageIcon>
@@ -18,8 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Seq.Apps" Version="2023.4.0" />
-    <PackageReference Include="Serilog" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.3" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Second attempt at https://github.com/datalust/seq-tickets/issues/2095

Older Seq versions will still be able to use earlier versions of this package; however, 2024.1+ servers will need this update.