### PR TITLE
Update to Serilog.Sinks.Seq version 9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Replicator [![Build status](https://ci.appveyor.com/api/projects/status/ggbm45lhwipiwmfk/branch/dev?svg=true)](https://ci.appveyor.com/project/datalust/seq-app-replication/branch/dev)
 
-The `Seq.App.Replication` plug-in, which forwards incoming events to another Seq server.
+The `Seq.App.Replication` plug-in, which forwards incoming events to another Seq server. Requires Seq 2025.1+.
 
-This app can be used to implement store-and-forward, or limited disaster recovery. For reliable built-in disaster recovery, 
-see [Setting up a DR Instance](https://docs.datalust.co/docs/setting-up-a-disaster-recovery-dr-instance) in the Seq documentation.
+This app can be used to implement store-and-forward to another Seq instance, for limited disaster recovery. For reliable built-in disaster recovery, 
+see [Clustering Overview](https://docs.datalust.co/docs/clustering-overview) in the Seq documentation.
+
+> [!NOTE]
+>
+> This app does not fully support traces or OpenTelemetry envelope properties like `@Resource` and `@Scope`. See [Seq.App.Relay](https://github.com/datalust/seq-app-relay) for an alternative implementation that supports all current Seq features.
+
+## Getting started
 
 Get started with these [instructions for installing Seq apps](https://docs.datalust.co/docs/installing-output-apps).

--- a/src/Seq.App.Replication/Replicator.cs
+++ b/src/Seq.App.Replication/Replicator.cs
@@ -7,61 +7,60 @@ using Serilog.Core;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global, UnusedType.Global, MemberCanBePrivate.Global
 
-namespace Seq.App.Replication
+namespace Seq.App.Replication;
+
+[SeqApp(
+    "Replicator",
+    Description = "Forwards events to a second Seq server instance.")]
+public sealed class Replicator : SeqApp, ISubscribeTo<LogEvent>, IDisposable
 {
-    [SeqApp(
-        "Replicator",
-        Description = "Forwards events to a second Seq server instance.")]
-    public class Replicator : SeqApp, ISubscribeTo<LogEvent>, IDisposable
+    Logger _replicaLogger;
+
+    [SeqAppSetting(
+        DisplayName = "Server URL",
+        HelpText = "The URL of the second Seq server instance, e.g. http://backup-seq.")]
+    public string ServerUrl { get; set; }
+
+    [SeqAppSetting(
+        DisplayName = "API key",
+        InputType = SettingInputType.Password,
+        IsOptional = true,
+        HelpText = "The API key to use when writing to the second server, if required.")]
+    public string ApiKey { get; set; }
+
+    [SeqAppSetting(
+        DisplayName = "Use durable log shipping",
+        IsOptional = true,
+        HelpText = "If set, logs will be buffered durably (local disk) before forwarding;" +
+                   " otherwise only memory buffering is used and message loss may be more common.")]
+    public bool IsDurable { get; set; }
+
+    protected override void OnAttached()
     {
-        Logger _replicaLogger;
+        var apiKey = string.IsNullOrWhiteSpace(ApiKey) ? null : ApiKey.Trim();
 
-        [SeqAppSetting(
-            DisplayName = "Server URL",
-            HelpText = "The URL of the second Seq server instance, e.g. http://backup-seq.")]
-        public string ServerUrl { get; set; }
+        var bufferBase = IsDurable ? Path.Combine(App.StoragePath, "Buffer", "replicate") : null;
 
-        [SeqAppSetting(
-            DisplayName = "API key",
-            InputType = SettingInputType.Password,
-            IsOptional = true,
-            HelpText = "The API key to use when writing to the second server, if required.")]
-        public string ApiKey { get; set; }
+        _replicaLogger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Seq(
+                ServerUrl,
+                batchPostingLimit: 1000,
+                period: TimeSpan.FromMilliseconds(100),
+                apiKey: apiKey,
+                bufferBaseFilename: bufferBase)
+            .CreateLogger();
+    }
 
-        [SeqAppSetting(
-            DisplayName = "Use durable log shipping",
-            IsOptional = true,
-            HelpText = "If set, logs will be buffered durably (local disk) before forwarding;" +
-                       " otherwise only memory buffering is used and message loss may be more common.")]
-        public bool IsDurable { get; set; }
+    public void Dispose()
+    {
+        _replicaLogger.Dispose();
+    }
 
-        protected override void OnAttached()
-        {
-            var apiKey = string.IsNullOrWhiteSpace(ApiKey) ? null : ApiKey.Trim();
-
-            var bufferBase = IsDurable ? Path.Combine(App.StoragePath, "Buffer", "replicate") : null;
-
-            _replicaLogger = new LoggerConfiguration()
-                .MinimumLevel.Verbose()
-                .WriteTo.Seq(
-                    ServerUrl,
-                    batchPostingLimit: 1000,
-                    period: TimeSpan.FromMilliseconds(100),
-                    apiKey: apiKey,
-                    bufferBaseFilename: bufferBase)
-                .CreateLogger();
-        }
-
-        public void Dispose()
-        {
-            _replicaLogger.Dispose();
-        }
-
-        public void On(Event<LogEvent> evt)
-        {
-            evt.Data.RemovePropertyIfPresent("@i");
-            evt.Data.RemovePropertyIfPresent("@seqid");
-            _replicaLogger.Write(evt.Data);
-        }
+    public void On(Event<LogEvent> evt)
+    {
+        evt.Data.RemovePropertyIfPresent("@i");
+        evt.Data.RemovePropertyIfPresent("@seqid");
+        _replicaLogger.Write(evt.Data);
     }
 }

--- a/src/Seq.App.Replication/Seq.App.Replication.csproj
+++ b/src/Seq.App.Replication/Seq.App.Replication.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <VersionPrefix>5.0.1</VersionPrefix>
-    <Description>A simple event forwarder for Seq. Requires Seq 2024.1+.</Description>
+    <VersionPrefix>6.0.0</VersionPrefix>
+    <Description>A simple event forwarder for Seq. Requires Seq 2025.1+.</Description>
     <Authors>Datalust and Contributors</Authors>
     <PackageTags>seq-app</PackageTags>
     <PackageIcon>seq-app-replication.png</PackageIcon>
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Seq.Apps" Version="2023.4.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a breaking change in support of Seq 2025.1; older servers will need to use version 5.0.0 of this app instead.
